### PR TITLE
This can be considered a "test" pull request. Very minor change.

### DIFF
--- a/R/tree.plot.r
+++ b/R/tree.plot.r
@@ -347,6 +347,7 @@ is.standard.layout <- function(x) {
 
 #' Returns a data frame defining segments to draw the phylogenetic tree.
 #' 
+#' @importFrom plyr rbind.fill
 #' @export
 tree.layout <- function(
   phylo,


### PR DESCRIPTION
Since this is also imported elsewhere in the package, this doesn't
change the package behavior, but I did happen to miss the import when I
was "borrowing" tree.layout for my own package.
# ' @importFrom plyr rbind.fil

I don't think this affects the NAMESPACE file for now, unless the other
function that uses this, tree.as.data.frame, is removed or has this
dependency tag removed.

Very minor change, but thought I'd see how the pull request goes :)

As a side-note, very soon I'll be integrating some of the ggphylo code
into phyloseq, attributing you as author and linking to this repo.
